### PR TITLE
args.sidecars fixes

### DIFF
--- a/file_mapper_script.py
+++ b/file_mapper_script.py
@@ -210,9 +210,11 @@ def parse_data(contents, verbose=False, testdebug=False):
                     overwrite=args.overwrite, testdebug=args.testdebug, relsym=args.relative_symlink)
                     if args.sidecars:
                         json_src, json_dest = map_sidecars(source, destination)
-                        do_action(json_src, json_dest, args.action,
-                                  testdebug=args.testdebug,
-                                  relsym=args.relative_symlink)
+                        if os.path.isfile(json_src):
+                            do_action(json_src, json_dest, args.action,
+                                      overwrite=args.overwrite,
+                                      testdebug=args.testdebug,
+                                      relsym=args.relative_symlink)
                     if verbose:
                         print("File has been overwritten")
                 elif os.path.exists(dirname):
@@ -222,9 +224,10 @@ def parse_data(contents, verbose=False, testdebug=False):
                 do_action(source, destination, args.action, testdebug=args.testdebug, relsym=args.relative_symlink)
                 if args.sidecars:
                     json_src, json_dest = map_sidecars(source, destination)
-                    do_action(json_src, json_dest, args.action,
-                              testdebug=args.testdebug,
-                              relsym=args.relative_symlink)
+                    if os.path.isfile(json_src):
+                        do_action(json_src, json_dest, args.action,
+                                  testdebug=args.testdebug,
+                                  relsym=args.relative_symlink)
             else:
                 os.makedirs( dirname )
                 if verbose:
@@ -232,9 +235,10 @@ def parse_data(contents, verbose=False, testdebug=False):
                 do_action(source, destination, args.action, testdebug=args.testdebug, relsym=args.relative_symlink)
                 if args.sidecars:
                     json_src, json_dest = map_sidecars(source, destination)
-                    do_action(json_src, json_dest, args.action,
-                              testdebug=args.testdebug,
-                              relsym=args.relative_symlink)
+                    if os.path.isfile(json_src):
+                        do_action(json_src, json_dest, args.action,
+                                  testdebug=args.testdebug,
+                                  relsym=args.relative_symlink)
 
 
 

--- a/file_mapper_script.py
+++ b/file_mapper_script.py
@@ -208,7 +208,7 @@ def parse_data(contents, verbose=False, testdebug=False):
                 elif args.overwrite:
                     do_action(source, destination, args.action,
                     overwrite=args.overwrite, testdebug=args.testdebug, relsym=args.relative_symlink)
-                    if args.sidecars:
+                    if args.sidecars and ( source.endswith('.nii') or source.endswith('.nii.gz') ):
                         json_src, json_dest = map_sidecars(source, destination)
                         if os.path.isfile(json_src):
                             do_action(json_src, json_dest, args.action,
@@ -222,7 +222,7 @@ def parse_data(contents, verbose=False, testdebug=False):
                         print("Path already exists: " + str(dirname))
             elif os.path.isdir(os.path.dirname(destination)):
                 do_action(source, destination, args.action, testdebug=args.testdebug, relsym=args.relative_symlink)
-                if args.sidecars:
+                if args.sidecars and ( source.endswith('.nii') or source.endswith('.nii.gz') ):
                     json_src, json_dest = map_sidecars(source, destination)
                     if os.path.isfile(json_src):
                         do_action(json_src, json_dest, args.action,
@@ -233,7 +233,7 @@ def parse_data(contents, verbose=False, testdebug=False):
                 if verbose:
                     print("Path has been made: " + str(dirname))
                 do_action(source, destination, args.action, testdebug=args.testdebug, relsym=args.relative_symlink)
-                if args.sidecars:
+                if args.sidecars and ( source.endswith('.nii') or source.endswith('.nii.gz') ):
                     json_src, json_dest = map_sidecars(source, destination)
                     if os.path.isfile(json_src):
                         do_action(json_src, json_dest, args.action,


### PR DESCRIPTION
These fixes are for the args.sidecars option. They correct two things:

1. Only using the args.sidecars option when the source is a .nii or a .nii.gz (the lower-level function would break otherwise).
2. Checking if the json_src is an existent file before doing a file-mapping. This prevents the case where a broken link gets created.

One possible improvement would be to still allow file-mapping even if json_src was not a file, like a symbolic link for instance. Not a great habit, but you should be able to make symbolic links to symbolic links still.